### PR TITLE
Improve project close dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Improve project close dialog ([#9](https://github.com/ChrisCarini/git-push-reminder-jetbrains-plugin/pull/9))
 
 ### Deprecated
 

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitPushReminder.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitPushReminder.java
@@ -5,6 +5,7 @@ import com.chriscarini.jetbrains.gitpushreminder.settings.SettingsManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectCloseHandler;
+import com.intellij.openapi.ui.MessageConstants;
 import com.intellij.openapi.ui.Messages;
 import git4idea.GitLocalBranch;
 import git4idea.GitReference;
@@ -40,23 +41,23 @@ public class GitPushReminder implements ProjectCloseHandler {
         boolean canClose = branchesWithUnpushedCommits.isEmpty();
 
         if (!canClose && SettingsManager.getInstance().getState().showDialog) {
-            Messages.showMessageDialog(
-                project,
+            final int dialogResult = Messages.showOkCancelDialog(project,
                 PluginMessages.get("git.push.reminder.closing.dialog.body.unpushed.branches",
-                    branchesWithUnpushedCommits.stream().map(GitReference::getName).collect(Collectors.joining("</li><li>")),
-                    SettingsManager.getInstance().getState().preventClose ?
-                        PluginMessages.get("git.push.reminder.closing.dialog.body.note") :
-                        ""
+                    branchesWithUnpushedCommits.stream()
+                        .map(GitReference::getName)
+                        .sorted()
+                        .collect(Collectors.joining("</li><li>"))
                 ),
                 PluginMessages.get("git.push.reminder.closing.dialog.title"),
-                SettingsManager.getInstance().getState().preventClose ? Messages.getErrorIcon() : Messages.getWarningIcon()
+                PluginMessages.get("git.push.reminder.closing.dialog.button.close.anyway"),
+                PluginMessages.get("git.push.reminder.closing.dialog.button.keep.project.open"),
+                Messages.getWarningIcon()
             );
+
+            return dialogResult == MessageConstants.OK;
+
         }
 
-        if (SettingsManager.getInstance().getState().preventClose) {
-            // We can close if there are *NO* unpushed commits.
-            return canClose;
-        }
         return true;
     }
 

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsConfigurable.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsConfigurable.java
@@ -24,7 +24,6 @@ public class SettingsConfigurable implements Configurable {
     private final JBCheckBox checkAllBranchesField = new JBCheckBox();
     private final JBCheckBox countUntrackedBranchAsPushedField = new JBCheckBox();
     private final JBCheckBox showDialogField = new JBCheckBox();
-    private final JBCheckBox preventCloseField = new JBCheckBox();
 
     public SettingsConfigurable() {
         buildMainPanel();
@@ -49,10 +48,6 @@ public class SettingsConfigurable implements Configurable {
                 .addSeparator()
                 .addLabeledComponent(PluginMessages.get("git.push.reminder.settings.show.dialog.label"), showDialogField)
                 .addTooltip(PluginMessages.get("git.push.reminder.settings.show.dialog.tooltip"))
-                .addSeparator()
-                .addLabeledComponent(PluginMessages.get("git.push.reminder.settings.prevent.closing.project.label"), preventCloseField)
-                .addTooltip(PluginMessages.get("git.push.reminder.settings.prevent.closing.project.tooltip"))
-                .addSeparator()
                 .getPanel()
         );
     }
@@ -89,7 +84,6 @@ public class SettingsConfigurable implements Configurable {
         settingsState.checkAllBranches = checkAllBranchesField.isSelected();
         settingsState.countUntrackedBranchAsPushed = countUntrackedBranchAsPushedField.isSelected();
         settingsState.showDialog = showDialogField.isSelected();
-        settingsState.preventClose = preventCloseField.isSelected();
 
         return settingsState;
     }
@@ -114,7 +108,6 @@ public class SettingsConfigurable implements Configurable {
         checkAllBranchesField.setSelected(settings.checkAllBranches);
         countUntrackedBranchAsPushedField.setSelected(settings.countUntrackedBranchAsPushed);
         showDialogField.setSelected(settings.showDialog);
-        preventCloseField.setSelected(settings.preventClose);
     }
 
     @NotNull

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsManager.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsManager.java
@@ -40,13 +40,11 @@ public class SettingsManager implements PersistentStateComponent<SettingsManager
         public boolean checkAllBranches;
         public boolean countUntrackedBranchAsPushed;
         public boolean showDialog;
-        public boolean preventClose;
 
         public GitPushReminderSettingsState() {
             this.checkAllBranches = false;
             this.countUntrackedBranchAsPushed = false;
             this.showDialog = true;
-            this.preventClose = false;
         }
 
         @Override
@@ -54,12 +52,12 @@ public class SettingsManager implements PersistentStateComponent<SettingsManager
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             GitPushReminderSettingsState that = (GitPushReminderSettingsState) o;
-            return checkAllBranches == that.checkAllBranches && countUntrackedBranchAsPushed == that.countUntrackedBranchAsPushed && showDialog == that.showDialog && preventClose == that.preventClose;
+            return checkAllBranches == that.checkAllBranches && countUntrackedBranchAsPushed == that.countUntrackedBranchAsPushed && showDialog == that.showDialog;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(checkAllBranches, countUntrackedBranchAsPushed, showDialog, preventClose);
+            return Objects.hash(checkAllBranches, countUntrackedBranchAsPushed, showDialog);
         }
     }
 }

--- a/src/main/resources/messages/gitPushReminder.properties
+++ b/src/main/resources/messages/gitPushReminder.properties
@@ -1,12 +1,11 @@
-git.push.reminder.closing.dialog.body.note=<br/><b>Note:</b> Your settings indicate you want to prevent the project from closing when there are un-pushed commits. Clicking 'ok' will keep the project open.
-git.push.reminder.closing.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits. Please push before closing!<br/><br/><b>Branch(s):</b><ul><li>{0}</li></ul>{1}</html>
+git.push.reminder.closing.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits. Would you like to close the project anyway?<br/><br/><b>Branch(s):</b><ul><li>{0}</li></ul></html>
+git.push.reminder.closing.dialog.button.close.anyway=Close Anyway
+git.push.reminder.closing.dialog.button.keep.project.open=Keep Project Open
 git.push.reminder.closing.dialog.title=Un-Pushed Local Commits Detected!
 git.push.reminder.settings.allow.untracked.branches.label=Allow untracked branches
 git.push.reminder.settings.allow.untracked.branches.tooltip=<html>If checked, local branches with no tracked remote branch will be 'allowed'.<br/>If unchecked, local branches will need to have a tracked remote branch.</html>
 git.push.reminder.settings.check.all.branches.label=Check all branches?
 git.push.reminder.settings.check.all.branches.tooltip=<html>If checked, all local branches will be checked.<br/>If unchecked, only the current branch will be checked.</html>
 git.push.reminder.settings.display.name=Git Push Reminder
-git.push.reminder.settings.prevent.closing.project.label=Prevent closing project
-git.push.reminder.settings.prevent.closing.project.tooltip=<html>If checked, any un-pushed commits will prevent the project from being able to be closed.<br/>If unchecked, un-pushed commits will not prevent project closure.</html>
 git.push.reminder.settings.show.dialog.label=Show dialog?
-git.push.reminder.settings.show.dialog.tooltip=<html>If checked, a dialog will be shown if there are any un-pushed branches.<br/>If unchecked, no dialog box will be shown.</html>
+git.push.reminder.settings.show.dialog.tooltip=<html>If checked, a dialog will be shown if there are any un-pushed branches.<br/>If unchecked, no dialog box will be shown and the project will be allowed to close without notice.</html>

--- a/src/main/resources/messages/gitPushReminder_en.properties
+++ b/src/main/resources/messages/gitPushReminder_en.properties
@@ -1,12 +1,11 @@
-git.push.reminder.closing.dialog.body.note=<br/><b>Note:</b> Your settings indicate you want to prevent the project from closing when there are un-pushed commits. Clicking 'ok' will keep the project open.
-git.push.reminder.closing.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits. Please push before closing!<br/><br/><b>Branch(s):</b><ul><li>{0}</li></ul>{1}</html>
+git.push.reminder.closing.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits. Would you like to close the project anyway?<br/><br/><b>Branch(s):</b><ul><li>{0}</li></ul></html>
+git.push.reminder.closing.dialog.button.close.anyway=Close Anyway
+git.push.reminder.closing.dialog.button.keep.project.open=Keep Project Open
 git.push.reminder.closing.dialog.title=Un-Pushed Local Commits Detected!
 git.push.reminder.settings.allow.untracked.branches.label=Allow untracked branches
 git.push.reminder.settings.allow.untracked.branches.tooltip=<html>If checked, local branches with no tracked remote branch will be 'allowed'.<br/>If unchecked, local branches will need to have a tracked remote branch.</html>
 git.push.reminder.settings.check.all.branches.label=Check all branches?
 git.push.reminder.settings.check.all.branches.tooltip=<html>If checked, all local branches will be checked.<br/>If unchecked, only the current branch will be checked.</html>
 git.push.reminder.settings.display.name=Git Push Reminder
-git.push.reminder.settings.prevent.closing.project.label=Prevent closing project
-git.push.reminder.settings.prevent.closing.project.tooltip=<html>If checked, any un-pushed commits will prevent the project from being able to be closed.<br/>If unchecked, un-pushed commits will not prevent project closure.</html>
 git.push.reminder.settings.show.dialog.label=Show dialog?
-git.push.reminder.settings.show.dialog.tooltip=<html>If checked, a dialog will be shown if there are any un-pushed branches.<br/>If unchecked, no dialog box will be shown.</html>
+git.push.reminder.settings.show.dialog.tooltip=<html>If checked, a dialog will be shown if there are any un-pushed branches.<br/>If unchecked, no dialog box will be shown and the project will be allowed to close without notice.</html>


### PR DESCRIPTION
# Summary

This change removes the user configuration setting for preventing the project from closing, and replaces it with a more explicit dialog for the user to choose to close the project, or keep it open (see below screenshot).

# Screenshot(s)

<img width="486" alt="Screen Shot 2022-07-30 at 00 14 16" src="https://user-images.githubusercontent.com/6374067/181879717-197ed570-4538-42bd-9636-6d0072c7bee7.png">


Resolves #8