### PR TITLE
Upgrading IntelliJ from 2023.1.3 to 2023.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.1.3 to 2023.1.4
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Git Push Reminder'
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.3
+pluginVersion = 1.0.4
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 1.0.3
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.1.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.1.4,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -26,7 +26,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.1.3
+platformVersion = 2023.1.4
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.1.3 to 2023.1.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661616/IntelliJ-IDEA-2023.1.4-231.9225.16-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.1.4 is out with the following fixes: 
<ul> 
 <li>We fixed the issue with missing custom code style settings and they are now correctly preserved by the IDE. [<a href="https://youtrack.jetbrains.com/issue/IDEA-318457/">IDEA-318457</a>]</li> 
 <li>The<em> Copy Reference</em> action for files in non-java modules works as expected and copies the path from the content root. [<a href="https://youtrack.jetbrains.com/issue/IDEA-316752">IDEA-316752</a>]</li> 
 <li>The <em>@jakarta.validation.constraints.NotNull</em> annotation is now interpreted correctly during nullability inspections. [<a href="https://youtrack.jetbrains.com/issue/IDEA-323547">IDEA-323547</a>]</li> 
 <li>Starting up the IDE no longer fails with the <em>"CannotActivateException: Address already in use: bind"</em> error. [<a href="https://youtrack.jetbrains.com/issue/IDEA-323836">IDEA-323836</a>]</li> 
 <li>The IDE now has full Wildfly 28 support. [<a href="https://youtrack.jetbrains.com/issue/IDEA-320285/">IDEA-320285</a>]</li> 
</ul> For more details, refer to this 
<a href="https://blog.jetbrains.com/idea/2023/07/intellij-idea-2023-1-4/">blog post</a>.
    