### PR TITLE
Upgrading IntelliJ from 2023.2.5 to 2023.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.2.5 to 2023.3.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Git Push Reminder'
 # SemVer format -> https://semver.org
-pluginVersion = 1.1.5
+pluginVersion = 1.2.0
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 1.1.5
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.2.5,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -26,7 +26,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.2.5
+platformVersion = 2023.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.2.5 to 2023.3.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661779/IntelliJ-IDEA-2023.3-233.11799.241-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.3 is now available with the following new features: 
<ul> 
 <li>AI Assistant, which is now out of preview</li> 
 <li>Full support for Java 21</li> 
 <li><em>Run to Cursor</em> inlay option in the debugger</li> 
 <li>Floating toolbar with editing actions</li> 
 <li>Streamlined out-of-the-box Kubernetes development experience</li> 
</ul> Visit our 
<a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about these and other improvements.
    