### PR TITLE
Fix confusing UX when switching branches with unpushed changes on two branches with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Removed
 
 ### Fixed
+- Fix confusing UX when switching branches with unpushed changes on two branches with the same name ([#253](https://github.com/ChrisCarini/git-push-reminder-jetbrains-plugin/issues/253))
 
 ### Security
 

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitBranchChangeListener.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitBranchChangeListener.java
@@ -37,7 +37,7 @@ public class GitBranchChangeListener implements BranchChangeListener {
                     PluginMessages.get("git.push.reminder.switching.dialog.body.unpushed.branches",
                             repositoryAndBranch.branch().getName()
                     ),
-                    PluginMessages.get("git.push.reminder.closing.dialog.title"),
+                    PluginMessages.get("git.push.reminder.closing.dialog.title", ""),
                     PluginMessages.get("git.push.reminder.switching.dialog.button.push"),
                     PluginMessages.get("git.push.reminder.switching.dialog.button.dontpush"),
                     Messages.getWarningIcon()

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitPushReminder.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitPushReminder.java
@@ -25,11 +25,21 @@ public class GitPushReminder implements ProjectCloseHandler {
             final int dialogResult = Messages.showOkCancelDialog(project,
                 PluginMessages.get("git.push.reminder.closing.dialog.body.unpushed.branches",
                     branchesWithUnpushedCommits.stream()
-                        .map(repoAndBranch -> repoAndBranch.branch().getName())
-                        .sorted()
+                            .sorted((o1, o2) -> {
+                                if (o1.repository().getRoot().getName().equals(o2.repository().getRoot().getName())) {
+                                    return o1.branch().getName().compareTo(o2.branch().getName());
+                                }
+                                return o1.repository().getRoot().getName().compareTo(o2.repository().getRoot().getName());
+                            })
+                        .map(repoAndBranch -> String.format(
+                                "%s (%s)", //NON-NLS
+                                repoAndBranch.branch().getName(),
+                                repoAndBranch.repository().getRoot().getName()
+                            )
+                         )
                         .collect(Collectors.joining("</li><li>"))
                 ),
-                PluginMessages.get("git.push.reminder.closing.dialog.title"),
+                PluginMessages.get("git.push.reminder.closing.dialog.title", branchesWithUnpushedCommits.size()),
                 PluginMessages.get("git.push.reminder.closing.dialog.button.close.anyway"),
                 PluginMessages.get("git.push.reminder.closing.dialog.button.keep.project.open"),
                 Messages.getWarningIcon()

--- a/src/main/resources/messages/gitPushReminder.properties
+++ b/src/main/resources/messages/gitPushReminder.properties
@@ -1,7 +1,7 @@
 git.push.reminder.closing.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits. Would you like to close the project anyway?<br/><br/><b>Branch(s):</b><ul><li>{0}</li></ul></html>
 git.push.reminder.closing.dialog.button.close.anyway=Close Anyway
 git.push.reminder.closing.dialog.button.keep.project.open=Keep Project Open
-git.push.reminder.closing.dialog.title=Un-Pushed Local Commits Detected!
+git.push.reminder.closing.dialog.title={0} Un-Pushed Local Commit(s) Detected!
 git.push.reminder.switching.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits on {0}. Would you like to push them now?</html>
 git.push.reminder.switching.dialog.button.push=Push
 git.push.reminder.switching.dialog.button.dontpush=Continue without push

--- a/src/main/resources/messages/gitPushReminder_en.properties
+++ b/src/main/resources/messages/gitPushReminder_en.properties
@@ -1,7 +1,7 @@
 git.push.reminder.closing.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits. Would you like to close the project anyway?<br/><br/><b>Branch(s):</b><ul><li>{0}</li></ul></html>
 git.push.reminder.closing.dialog.button.close.anyway=Close Anyway
 git.push.reminder.closing.dialog.button.keep.project.open=Keep Project Open
-git.push.reminder.closing.dialog.title=Un-Pushed Local Commits Detected!
+git.push.reminder.closing.dialog.title={0} Un-Pushed Local Commit(s) Detected!
 git.push.reminder.switching.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits on {0}. Would you like to push them now?</html>
 git.push.reminder.switching.dialog.button.push=Push
 git.push.reminder.switching.dialog.button.dontpush=Continue without push


### PR DESCRIPTION
Resolves #253