### PR TITLE
Upgrading IntelliJ from 2024.1.1 to 2024.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.1.1 to 2024.1.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Git Push Reminder'
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.1
+pluginVersion = 2.0.2
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -13,7 +13,7 @@ pluginUntilBuild = 241.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.1.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.1.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -25,7 +25,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1.1
+platformVersion = 2024.1.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.1.1 to 2024.1.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661977/IntelliJ-IDEA-2024.1.2-241.17011.79-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.1.2 is out with the following updates: 
<ul> 
 <li>The IDE no longer crashes when using the new Ubuntu 24 distribution family. [<a href="https://youtrack.jetbrains.com/issue/IJPL-59368/">IJPL-59368</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-59369/">IJPL-59369</a>]</li> 
 <li>Erroneous syntax highlighting no longer occurs when sticky lines are enabled. [<a href="https://youtrack.jetbrains.com/issue/IJPL-26873/">IJPL-26873</a>]</li> 
 <li>The <em>Synchronize Selected</em> functionality once again works as expected for directory comparisons. [<a href="https://youtrack.jetbrains.com/issue/IJPL-99511">IJPL-99511</a>]</li> 
 <li>Font and letter spacing are now properly displayed in the <em>Terminal</em> tool window when the <em>Use color scheme font instead of the default</em> option is enabled. [<a href="https://youtrack.jetbrains.com/issue/IJPL-36999/">IJPL-36999</a>]</li> 
 <li>The IDE no longer provides erroneous shellcheck update suggestions. [<a href="https://youtrack.jetbrains.com/issue/IJPL-103024/">IJPL-103024</a>]</li> 
</ul> Get more details in our 
<a href="https://blog.jetbrains.com/idea/2024/05/intellij-idea-2024-1-2/">blog post</a>.
    