### PR TITLE
Upgrading IntelliJ from 2024.1.4 to 2024.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.1.4 to 2024.1.5
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Git Push Reminder'
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.4
+pluginVersion = 2.0.5
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -13,7 +13,7 @@ pluginUntilBuild = 241.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.1.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.1.5,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -25,7 +25,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1.4
+platformVersion = 2024.1.5
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.1.4 to 2024.1.5

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662071/IntelliJ-IDEA-2024.1.5-241.18968.26-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.1.5 is out with the following improvements: 
<ul> 
 <li>Fixed the issue where the terminal would open slowly when the ulimit -n value was set too high. [<a href="https://youtrack.jetbrains.com/issue/IJPL-103736/Terminal-slow-to-open-when-ulimit-n-is-too-high">IJPL-103736</a>]</li> 
 <li>The HTTP Client no longer sends an HTTP request with a Content-Type: text/plain header when a specific Content-Type has already been set by the user. [<a href="https://youtrack.jetbrains.com/issue/IJPL-65366/HTTP-Client-multipart-form-data-Request-forces-text-plain-content-type">IJPL-65366</a>]</li> 
 <li>Fixed the issue where viewing package details in the package.json sometimes resulted in an exception. [<a href="https://youtrack.jetbrains.com/issue/IJPL-150388/Exception-on-viewing-package-details-in-the-package.json">IJPL-150388</a>]</li> 
</ul> Get more details in our 
<a href="https://blog.jetbrains.com/idea/2024/08/intellij-idea-2024-1-5/">blog post</a>.
    