### PR TITLE
Bump org.jetbrains.intellij.platform:intellij-platform-gradle-plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.intellij.platform:intellij-platform-gradle-plugin:2.0.1")
+    implementation("org.jetbrains.intellij.platform:intellij-platform-gradle-plugin:2.1.0")
     implementation("org.jetbrains.intellij.plugins:gradle-changelog-plugin:2.2.1")
     implementation("com.dorongold.plugins:task-tree:4.0.0") // provides `taskTree` task (e.g. `./gradlew build taskTree`; docs: https://github.com/dorongold/gradle-task-tree)
 }


### PR DESCRIPTION
Bumps org.jetbrains.intellij.platform:intellij-platform-gradle-plugin from 2.0.1 to 2.1.0.