### PR TITLE
Show dialog when untracked files, or uncommitted changes are detected.

### DIFF
--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitPushReminder.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitPushReminder.java
@@ -1,8 +1,18 @@
 package com.chriscarini.jetbrains.gitpushreminder;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.intellij.ide.SaveAndSyncHandler;
+import com.intellij.openapi.progress.util.BackgroundTaskUtil;
+import com.intellij.openapi.vcs.FilePath;
+import com.intellij.openapi.vcs.changes.VcsManagedFilesHolder;
+import com.intellij.util.Time;
+import git4idea.index.GitFileStatus;
+import git4idea.repo.GitRepositoryManager;
+import git4idea.status.GitStagingAreaHolder;
 import org.jetbrains.annotations.NotNull;
 
 import com.chriscarini.jetbrains.gitpushreminder.messages.PluginMessages;
@@ -13,41 +23,135 @@ import com.intellij.openapi.ui.MessageConstants;
 import com.intellij.openapi.ui.Messages;
 
 public class GitPushReminder implements ProjectCloseHandler {
+    private static final int TIME_BETWEEN = 2 * Time.SECOND;
+    private long lastRanTime = System.currentTimeMillis() - TIME_BETWEEN - 1;
+    private final List<String> body = new ArrayList<>();
 
+    /**
+     * We can close the project if/when all the following criteria are met:
+     * <p>
+     * 0. If "Show dialog?" IS UNCHECKED --> TRUE
+     * 1. "Allow uncommitted changes" is UNCHECKED &&& There are uncommitted changes --> Show Dialog
+     * 2. "Allow untracked branches" is UNCHECKED &&& There are untracked branches --> Show Dialog
+     * 3. "Allow untracked files" is UNCHECKED &&& There are untracked files --> Show Dialog
+     * 4. Otherwise, Show Dialog (if needed) and do what the user wants, else TRUE
+     *
+     * @param project project to check
+     * @return true if the project can be closed, false otherwise
+     */
     @Override
     public boolean canClose(@NotNull Project project) {
-        final List<GitHelper.RepositoryAndBranch> branchesWithUnpushedCommits = GitHelper.getBranchesWithUnpushedCommits(project, SettingsManager.getInstance().getState().checkAllBranches);
+        // Sometimes upon program exit (not project close), two dialogs are shown. 
+        // `lastRanTime` is a mechanism to prevent that from happening.
+        if (System.currentTimeMillis() - lastRanTime < TIME_BETWEEN) {
+            return true;
+        }
 
-        // If there are *NO* branches with outgoing/un-pushed commits, then we can close.
-        boolean canClose = branchesWithUnpushedCommits.isEmpty();
+        /*
+         *  - Show dialog?
+         *      - If checked, a dialog will be shown if there are any un-pushed branches, untracked files, or uncommitted changes.
+         *      - If unchecked, no dialog box will be shown and the project will be allowed to close without notice.
+         *
+         *  0. If "Show dialog?" IS UNCHECKED --> TRUE
+         */
+        if (!SettingsManager.getInstance().getState().showDialog) {
+            return true;
+        }
 
-        if (!canClose && SettingsManager.getInstance().getState().showDialog) {
-            final int dialogResult = Messages.showOkCancelDialog(project,
-                PluginMessages.get("git.push.reminder.closing.dialog.body.unpushed.branches",
-                    branchesWithUnpushedCommits.stream()
-                            .sorted((o1, o2) -> {
-                                if (o1.repository().getRoot().getName().equals(o2.repository().getRoot().getName())) {
-                                    return o1.branch().getName().compareTo(o2.branch().getName());
-                                }
-                                return o1.repository().getRoot().getName().compareTo(o2.repository().getRoot().getName());
-                            })
-                        .map(repoAndBranch -> String.format(
-                                "%s (%s)", //NON-NLS
-                                repoAndBranch.branch().getName(),
-                                repoAndBranch.repository().getRoot().getName()
-                            )
-                         )
-                        .collect(Collectors.joining("</li><li>"))
-                ),
-                PluginMessages.get("git.push.reminder.closing.dialog.title", branchesWithUnpushedCommits.size()),
+        // Clear any previous body of the dialog on each run
+        body.clear();
+
+        // Try to update the state of repos
+        SaveAndSyncHandler.getInstance().refreshOpenFiles();
+        BackgroundTaskUtil.syncPublisher(project, VcsManagedFilesHolder.TOPIC).updatingModeChanged();
+        GitRepositoryManager.getInstance(project).getRepositories().forEach(gitRepository -> {
+            BackgroundTaskUtil.syncPublisher(project, GitStagingAreaHolder.TOPIC).stagingAreaChanged(gitRepository);
+        });
+
+        /*
+         *  - Allow uncommitted changes
+         *      - If checked, uncommited changes in changelists will be 'allowed'.
+         *      - If unchecked, a dialog will be shown warning that uncommitted changes will need to be committed.
+         *
+         *  1. If "Allow uncommitted changes" is UNCHECKED &&& There are uncommitted changes --> Show Dialog
+         */
+        if (!SettingsManager.getInstance().getState().allowUncommitedChanges) {
+            final List<GitFileStatus> untrackedCommittedFiles = GitHelper.getFilesWithUncommittedChanges(project);
+            addToDialogBody(
+                    untrackedCommittedFiles,
+                    PluginMessages.get("git.push.reminder.closing.dialog.body.uncommitted.changes.title"),
+                    (gitFileStatus) -> gitFileStatus.getPath().getName()
+            );
+        }
+
+        /*
+         *  - Allow untracked branches
+         *      - If checked, local branches with no tracked remote branch will be 'allowed'.
+         *      - If unchecked, a dialog will be shown warning that local branches will need to have a tracked remote branch.
+         *
+         *  2. If "Allow untracked branches" is UNCHECKED &&& There are untracked branches --> Show Dialog
+         */
+        if (!SettingsManager.getInstance().getState().allowUntrackedBranches) {
+            final List<GitHelper.RepositoryAndBranch> untrackedBranches = GitHelper.getBranchesWithUnpushedCommits(project, SettingsManager.getInstance().getState().checkAllBranches);
+            addToDialogBody(
+                    untrackedBranches,
+                    PluginMessages.get("git.push.reminder.closing.dialog.body.untracked.branches.title"),
+                    repoAndBranch -> String.format("%s (%s)", repoAndBranch.branch().getName(), repoAndBranch.repository().getRoot().getName()) //NON-NLS
+            );
+        }
+
+        /*
+         *  - Allow untracked files
+         *      - If checked, untracked files which are not added to a changelist will be 'allowed'.
+         *      - If unchecked, a dialog will be shown warning that untracked files will need to become tracked.
+         *
+         *  3. If "Allow untracked files" is UNCHECKED &&& There are untracked files --> Show Dialog
+         */
+        if (!SettingsManager.getInstance().getState().allowUntrackedFiles) {
+            final List<FilePath> untrackedFiles = GitHelper.getUntrackedFiles(project);
+            addToDialogBody(
+                    untrackedFiles,
+                    PluginMessages.get("git.push.reminder.closing.dialog.body.untracked.files.title"),
+                    FilePath::getName
+            );
+        }
+
+        /*
+         *  4. Otherwise,
+         *      - if the user opted to "Keep Project Open" in the dialog -> FALSE
+         *      - Otherwise, TRUE
+         */
+        boolean okToClose = body.isEmpty() || doesUserWantProjectClosed(project, body);
+
+        // Note: `lastRanTime` needs to be updated *AFTER* the dialog is shown.
+        lastRanTime = System.currentTimeMillis();
+
+        return okToClose;
+    }
+
+    private <T> void addToDialogBody(
+            final List<T> checkList,
+            final String title,
+            final Function<T, String> mapper
+    ) {
+        if (!checkList.isEmpty()) {
+            final String listItems = checkList.stream()
+                    .map(mapper)
+                    .sorted()
+                    .collect(Collectors.joining("</li><li>"));
+            this.body.add(PluginMessages.get("git.push.reminder.closing.dialog.body.list.template", title, listItems));
+        }
+    }
+
+    private boolean doesUserWantProjectClosed(@NotNull final Project project, @NotNull final List<String> body) {
+        final int dialogResult = Messages.showOkCancelDialog(project,
+                PluginMessages.get("git.push.reminder.closing.dialog.body.template", String.join("", body)),
+                PluginMessages.get("git.push.reminder.closing.dialog.title"),
                 PluginMessages.get("git.push.reminder.closing.dialog.button.close.anyway"),
                 PluginMessages.get("git.push.reminder.closing.dialog.button.keep.project.open"),
                 Messages.getWarningIcon()
-            );
+        );
 
-            return dialogResult == MessageConstants.OK;
-        }
-
-        return true;
+        return dialogResult == MessageConstants.OK;
     }
 }

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitPushReminder.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/GitPushReminder.java
@@ -75,7 +75,7 @@ public class GitPushReminder implements ProjectCloseHandler {
          *
          *  1. If "Allow uncommitted changes" is UNCHECKED &&& There are uncommitted changes --> Show Dialog
          */
-        if (!SettingsManager.getInstance().getState().allowUncommitedChanges) {
+        if (!SettingsManager.getInstance().getState().allowUncommittedChanges) {
             final List<GitFileStatus> untrackedCommittedFiles = GitHelper.getFilesWithUncommittedChanges(project);
             addToDialogBody(
                     untrackedCommittedFiles,

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsConfigurable.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsConfigurable.java
@@ -94,7 +94,7 @@ public class SettingsConfigurable implements Configurable {
         final SettingsManager.GitPushReminderSettingsState settingsState = new SettingsManager.GitPushReminderSettingsState();
 
         settingsState.checkAllBranches = checkAllBranchesField.isSelected();
-        settingsState.allowUncommitedChanges = allowUncommittedChangesField.isSelected();
+        settingsState.allowUncommittedChanges = allowUncommittedChangesField.isSelected();
         settingsState.allowUntrackedBranches = allowUntrackedBranchField.isSelected();
         settingsState.allowUntrackedFiles = allowUntrackedFilesField.isSelected();
         settingsState.showDialog = showDialogField.isSelected();
@@ -121,7 +121,7 @@ public class SettingsConfigurable implements Configurable {
         }
 
         checkAllBranchesField.setSelected(settings.checkAllBranches);
-        allowUncommittedChangesField.setSelected(settings.allowUncommitedChanges);
+        allowUncommittedChangesField.setSelected(settings.allowUncommittedChanges);
         allowUntrackedBranchField.setSelected(settings.allowUntrackedBranches);
         allowUntrackedFilesField.setSelected(settings.allowUntrackedFiles);
         showDialogField.setSelected(settings.showDialog);

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsConfigurable.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsConfigurable.java
@@ -22,7 +22,9 @@ public class SettingsConfigurable implements Configurable {
     private final JPanel mainPanel = new JBPanel<>();
 
     private final JBCheckBox checkAllBranchesField = new JBCheckBox();
-    private final JBCheckBox countUntrackedBranchAsPushedField = new JBCheckBox();
+    private final JBCheckBox allowUncommittedChangesField = new JBCheckBox();
+    private final JBCheckBox allowUntrackedBranchField = new JBCheckBox();
+    private final JBCheckBox allowUntrackedFilesField = new JBCheckBox();
     private final JBCheckBox showDialogField = new JBCheckBox();
     private final JBCheckBox showSwitchDialogField = new JBCheckBox();
 
@@ -44,8 +46,14 @@ public class SettingsConfigurable implements Configurable {
                 .addLabeledComponent(PluginMessages.get("git.push.reminder.settings.check.all.branches.label"), checkAllBranchesField)
                 .addTooltip(PluginMessages.get("git.push.reminder.settings.check.all.branches.tooltip"))
                 .addSeparator()
-                .addLabeledComponent(PluginMessages.get("git.push.reminder.settings.allow.untracked.branches.label"), countUntrackedBranchAsPushedField)
+                .addLabeledComponent(PluginMessages.get("git.push.reminder.settings.allow.uncommitted.changes.label"), allowUncommittedChangesField)
+                .addTooltip(PluginMessages.get("git.push.reminder.settings.allow.uncommitted.changes.tooltip"))
+                .addSeparator()
+                .addLabeledComponent(PluginMessages.get("git.push.reminder.settings.allow.untracked.branches.label"), allowUntrackedBranchField)
                 .addTooltip(PluginMessages.get("git.push.reminder.settings.allow.untracked.branches.tooltip"))
+                .addSeparator()
+                .addLabeledComponent(PluginMessages.get("git.push.reminder.settings.allow.untracked.files.label"), allowUntrackedFilesField)
+                .addTooltip(PluginMessages.get("git.push.reminder.settings.allow.untracked.files.tooltip"))
                 .addSeparator()
                 .addLabeledComponent(PluginMessages.get("git.push.reminder.settings.show.dialog.label"), showDialogField)
                 .addTooltip(PluginMessages.get("git.push.reminder.settings.show.dialog.tooltip"))
@@ -86,7 +94,9 @@ public class SettingsConfigurable implements Configurable {
         final SettingsManager.GitPushReminderSettingsState settingsState = new SettingsManager.GitPushReminderSettingsState();
 
         settingsState.checkAllBranches = checkAllBranchesField.isSelected();
-        settingsState.countUntrackedBranchAsPushed = countUntrackedBranchAsPushedField.isSelected();
+        settingsState.allowUncommitedChanges = allowUncommittedChangesField.isSelected();
+        settingsState.allowUntrackedBranches = allowUntrackedBranchField.isSelected();
+        settingsState.allowUntrackedFiles = allowUntrackedFilesField.isSelected();
         settingsState.showDialog = showDialogField.isSelected();
         settingsState.showSwitchDialog = showSwitchDialogField.isSelected();
 
@@ -111,7 +121,9 @@ public class SettingsConfigurable implements Configurable {
         }
 
         checkAllBranchesField.setSelected(settings.checkAllBranches);
-        countUntrackedBranchAsPushedField.setSelected(settings.countUntrackedBranchAsPushed);
+        allowUncommittedChangesField.setSelected(settings.allowUncommitedChanges);
+        allowUntrackedBranchField.setSelected(settings.allowUntrackedBranches);
+        allowUntrackedFilesField.setSelected(settings.allowUntrackedFiles);
         showDialogField.setSelected(settings.showDialog);
         showSwitchDialogField.setSelected(settings.showSwitchDialog);
     }

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsManager.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsManager.java
@@ -37,14 +37,18 @@ public class SettingsManager implements PersistentStateComponent<SettingsManager
 
     public static class GitPushReminderSettingsState {
 
+        public boolean allowUncommitedChanges;
+        public boolean allowUntrackedBranches;
+        public boolean allowUntrackedFiles;
         public boolean checkAllBranches;
-        public boolean countUntrackedBranchAsPushed;
         public boolean showDialog;
         public boolean showSwitchDialog;
 
         public GitPushReminderSettingsState() {
+            this.allowUncommitedChanges = false;
+            this.allowUntrackedBranches = false;
+            this.allowUntrackedFiles = false;
             this.checkAllBranches = false;
-            this.countUntrackedBranchAsPushed = false;
             this.showDialog = true;
             this.showSwitchDialog = false;
         }
@@ -54,15 +58,24 @@ public class SettingsManager implements PersistentStateComponent<SettingsManager
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             GitPushReminderSettingsState that = (GitPushReminderSettingsState) o;
-            return checkAllBranches == that.checkAllBranches &&
-                    countUntrackedBranchAsPushed == that.countUntrackedBranchAsPushed &&
+            return allowUncommitedChanges == that.allowUncommitedChanges &&
+                    allowUntrackedBranches == that.allowUntrackedBranches &&
+                    allowUntrackedFiles == that.allowUntrackedFiles &&
+                    checkAllBranches == that.checkAllBranches &&
                     showDialog == that.showDialog &&
                     showSwitchDialog == that.showSwitchDialog;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(checkAllBranches, countUntrackedBranchAsPushed, showDialog, showSwitchDialog);
+            return Objects.hash(
+                    allowUncommitedChanges,
+                    allowUntrackedBranches,
+                    allowUntrackedFiles,
+                    checkAllBranches,
+                    showDialog,
+                    showSwitchDialog
+            );
         }
     }
 }

--- a/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsManager.java
+++ b/src/main/java/com/chriscarini/jetbrains/gitpushreminder/settings/SettingsManager.java
@@ -37,7 +37,7 @@ public class SettingsManager implements PersistentStateComponent<SettingsManager
 
     public static class GitPushReminderSettingsState {
 
-        public boolean allowUncommitedChanges;
+        public boolean allowUncommittedChanges;
         public boolean allowUntrackedBranches;
         public boolean allowUntrackedFiles;
         public boolean checkAllBranches;
@@ -45,7 +45,7 @@ public class SettingsManager implements PersistentStateComponent<SettingsManager
         public boolean showSwitchDialog;
 
         public GitPushReminderSettingsState() {
-            this.allowUncommitedChanges = false;
+            this.allowUncommittedChanges = false;
             this.allowUntrackedBranches = false;
             this.allowUntrackedFiles = false;
             this.checkAllBranches = false;
@@ -58,7 +58,7 @@ public class SettingsManager implements PersistentStateComponent<SettingsManager
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             GitPushReminderSettingsState that = (GitPushReminderSettingsState) o;
-            return allowUncommitedChanges == that.allowUncommitedChanges &&
+            return allowUncommittedChanges == that.allowUncommittedChanges &&
                     allowUntrackedBranches == that.allowUntrackedBranches &&
                     allowUntrackedFiles == that.allowUntrackedFiles &&
                     checkAllBranches == that.checkAllBranches &&
@@ -69,7 +69,7 @@ public class SettingsManager implements PersistentStateComponent<SettingsManager
         @Override
         public int hashCode() {
             return Objects.hash(
-                    allowUncommitedChanges,
+                    allowUncommittedChanges,
                     allowUntrackedBranches,
                     allowUntrackedFiles,
                     checkAllBranches,

--- a/src/main/resources/messages/gitPushReminder.properties
+++ b/src/main/resources/messages/gitPushReminder.properties
@@ -1,16 +1,24 @@
-git.push.reminder.closing.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits. Would you like to close the project anyway?<br/><br/><b>Branch(s):</b><ul><li>{0}</li></ul></html>
+git.push.reminder.closing.dialog.body.list.template=<b>{0}</b><ul><li>{1}</li></ul>
+git.push.reminder.closing.dialog.body.template=<html lang="en">Would you like to close the project anyway?<br/><br/>{0}</html>
+git.push.reminder.closing.dialog.body.uncommitted.changes.title=Uncommitted Changes(s):
+git.push.reminder.closing.dialog.body.untracked.branches.title=Untracked Branch(s):
+git.push.reminder.closing.dialog.body.untracked.files.title=Untracked Files(s):
 git.push.reminder.closing.dialog.button.close.anyway=Close Anyway
 git.push.reminder.closing.dialog.button.keep.project.open=Keep Project Open
-git.push.reminder.closing.dialog.title={0} Un-Pushed Local Commit(s) Detected!
+git.push.reminder.closing.dialog.title=Un-Pushed Branches / Files / Changes Detected!
 git.push.reminder.switching.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits on {0}. Would you like to push them now?</html>
 git.push.reminder.switching.dialog.button.push=Push
 git.push.reminder.switching.dialog.button.dontpush=Continue without push
+git.push.reminder.settings.allow.uncommitted.changes.label=Allow uncommitted changes
+git.push.reminder.settings.allow.uncommitted.changes.tooltip=<html>If checked, uncommited changes in changelists will be 'allowed'.<br/>If unchecked, a dialog will be shown warning that uncommitted changes will need to be committed.</html>
 git.push.reminder.settings.allow.untracked.branches.label=Allow untracked branches
 git.push.reminder.settings.allow.untracked.branches.tooltip=<html>If checked, local branches with no tracked remote branch will be 'allowed'.<br/>If unchecked, local branches will need to have a tracked remote branch.</html>
+git.push.reminder.settings.allow.untracked.files.label=Allow untracked files
+git.push.reminder.settings.allow.untracked.files.tooltip=<html>If checked, untracked files which are not added to a changelist will be 'allowed'.<br/>If unchecked, a dialog will be shown warning that untracked files will need to become tracked.</html>
 git.push.reminder.settings.check.all.branches.label=Check all branches?
 git.push.reminder.settings.check.all.branches.tooltip=<html>If checked, all local branches will be checked.<br/>If unchecked, only the current branch will be checked.</html>
 git.push.reminder.settings.display.name=Git Push Reminder
 git.push.reminder.settings.show.dialog.label=Show dialog?
-git.push.reminder.settings.show.dialog.tooltip=<html>If checked, a dialog will be shown if there are any un-pushed branches.<br/>If unchecked, no dialog box will be shown and the project will be allowed to close without notice.</html>
+git.push.reminder.settings.show.dialog.tooltip=<html>If checked, a dialog will be shown if there are any un-pushed branches, untracked files, or uncommitted changes.<br/>If unchecked, no dialog box will be shown and the project will be allowed to close without notice.<br/><b>Note:</b>The 'unchecked' setting is effectively disabling the plugin entirely.</html>
 git.push.reminder.settings.show.switch.dialog.label=Show dialog on branch switch?
 git.push.reminder.settings.show.switch.dialog.tooltip=<html>If checked, a dialog will be shown if the current branch is switched but still has unpushed commits.<br/>If unchecked, no dialog box will be shown.</html>

--- a/src/main/resources/messages/gitPushReminder_en.properties
+++ b/src/main/resources/messages/gitPushReminder_en.properties
@@ -1,16 +1,24 @@
-git.push.reminder.closing.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits. Would you like to close the project anyway?<br/><br/><b>Branch(s):</b><ul><li>{0}</li></ul></html>
+git.push.reminder.closing.dialog.body.list.template=<b>{0}</b><ul><li>{1}</li></ul>
+git.push.reminder.closing.dialog.body.template=<html lang="en">Would you like to close the project anyway?<br/><br/>{0}</html>
+git.push.reminder.closing.dialog.body.uncommitted.changes.title=Uncommitted Changes(s):
+git.push.reminder.closing.dialog.body.untracked.branches.title=Untracked Branch(s):
+git.push.reminder.closing.dialog.body.untracked.files.title=Untracked Files(s):
 git.push.reminder.closing.dialog.button.close.anyway=Close Anyway
 git.push.reminder.closing.dialog.button.keep.project.open=Keep Project Open
-git.push.reminder.closing.dialog.title={0} Un-Pushed Local Commit(s) Detected!
+git.push.reminder.closing.dialog.title=Un-Pushed Branches / Files / Changes Detected!
 git.push.reminder.switching.dialog.body.unpushed.branches=<html lang="en">There appear to be un-pushed commits on {0}. Would you like to push them now?</html>
 git.push.reminder.switching.dialog.button.push=Push
 git.push.reminder.switching.dialog.button.dontpush=Continue without push
+git.push.reminder.settings.allow.uncommitted.changes.label=Allow uncommitted changes
+git.push.reminder.settings.allow.uncommitted.changes.tooltip=<html>If checked, uncommited changes in changelists will be 'allowed'.<br/>If unchecked, a dialog will be shown warning that uncommitted changes will need to be committed.</html>
 git.push.reminder.settings.allow.untracked.branches.label=Allow untracked branches
 git.push.reminder.settings.allow.untracked.branches.tooltip=<html>If checked, local branches with no tracked remote branch will be 'allowed'.<br/>If unchecked, local branches will need to have a tracked remote branch.</html>
+git.push.reminder.settings.allow.untracked.files.label=Allow untracked files
+git.push.reminder.settings.allow.untracked.files.tooltip=<html>If checked, untracked files which are not added to a changelist will be 'allowed'.<br/>If unchecked, a dialog will be shown warning that untracked files will need to become tracked.</html>
 git.push.reminder.settings.check.all.branches.label=Check all branches?
 git.push.reminder.settings.check.all.branches.tooltip=<html>If checked, all local branches will be checked.<br/>If unchecked, only the current branch will be checked.</html>
 git.push.reminder.settings.display.name=Git Push Reminder
 git.push.reminder.settings.show.dialog.label=Show dialog?
-git.push.reminder.settings.show.dialog.tooltip=<html>If checked, a dialog will be shown if there are any un-pushed branches.<br/>If unchecked, no dialog box will be shown and the project will be allowed to close without notice.</html>
+git.push.reminder.settings.show.dialog.tooltip=<html>If checked, a dialog will be shown if there are any un-pushed branches, untracked files, or uncommitted changes.<br/>If unchecked, no dialog box will be shown and the project will be allowed to close without notice.<br/><b>Note:</b>The 'unchecked' setting is effectively disabling the plugin entirely.</html>
 git.push.reminder.settings.show.switch.dialog.label=Show dialog on branch switch?
 git.push.reminder.settings.show.switch.dialog.tooltip=<html>If checked, a dialog will be shown if the current branch is switched but still has unpushed commits.<br/>If unchecked, no dialog box will be shown.</html>


### PR DESCRIPTION
Based off changes started by @paul-dingemans in https://github.com/ChrisCarini/git-push-reminder-jetbrains-plugin/pull/405 , this PR adds to the dialog when untracked files or uncommitted changes are detected.

Fixes #404, fixes #409