### PR TITLE
Upgrading IntelliJ from 2024.3.2.1 to 2024.3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.2.1 to 2024.3.2.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/git-push-reminder-jetbrains
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 2.2.4
+pluginVersion = 2.2.5
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.3.2.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.3.2.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -35,7 +35,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.3.2.1
+platformVersion = 2024.3.2.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.2.1 to 2024.3.2.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662355/IntelliJ-IDEA-2024.3.2.2-243.23654.189-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3.2.2 is out! This update includes a hotfix for <a href="https://youtrack.jetbrains.com/issue/IDEA-342187/">IDEA-342187</a> that addresses an issue with Lombok in Maven projects. Check out <a href="https://youtrack.jetbrains.com/articles/IDEA-A-2100662355/IntelliJ-IDEA-2024.3.2.2-243.23654.189-build-Release-Notes"> the release notes</a> for all the details.
    