### PR TITLE
Upgrading IntelliJ from 2025.2.1 to 2025.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.2.1 to 2025.2.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/git-push-reminder-jetbrains
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 3.1.1
+pluginVersion = 3.1.2
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 252.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.2.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.2.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -35,7 +35,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.2.1
+platformVersion = 2025.2.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.2.1 to 2025.2.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662504/IntelliJ-IDEA-2025.2.2-252.26199.169-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.2.2 is available! Here are the most notable updates:</p>
<ul>
 <li>The <em>Run Maven Build</em> icon is once again available in the Maven panel toolbar. [<a href="https://youtrack.jetbrains.com/issue/IDEA-376149/">IDEA-376149</a>]</li>
 <li>Remote SSH external tools now work as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-200406/">IJPL-200406</a>]</li>
 <li>The IDE again correctly parses environment variables with semicolon values pasted in the <em>Run/Debug</em> dialog. [<a href="https://youtrack.jetbrains.com/issue/IJPL-200754/">IJPL-200754</a>]</li>
 <li>The IDE now properly handles MAVEN_OPTS environment variables. [<a href="https://youtrack.jetbrains.com/issue/IDEA-368366/">IDEA-368366</a>]</li>
 <li>On Windows, the <em>Find in Files</em> dialog again works as expected, closes correctly, and no longer shows a persistent green area. [<a href="https://youtrack.jetbrains.com/issue/IJPL-162798/">IJPL-162798</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2025/09/intellij-idea-2025-2-2/">blog post</a>.</p>
    