### PR TITLE
Upgrading IntelliJ from 2026.1.1 to 2026.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2026.1.1 to 2026.1.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/git-push-reminder-jetbrains
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 4.0.1
+pluginVersion = 4.0.2
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 261.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.1.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.1.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -33,7 +33,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.1.1
+platformVersion = 2026.1.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1.1 to 2026.1.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662679

# What's New?
<p>IntelliJ IDEA 2026.1.2 is out with the following improvements:
 <br></p>
<ul>
 <li>Projects can now be opened correctly via <code>.ipr</code>files generated by the Gradle <code>idea</code> task. [<a href="https://youtrack.jetbrains.com/issue/IJPL-242321/Project-cannot-be-opened-via-.ipr-file-generated-by-Gradle-idea-task">IJPL-242321</a>]</li>
 <li>The indentation for Java ternary expressions with chained method calls has been fixed. [<a href="https://youtrack.jetbrains.com/issue/IDEA-387867/Java-code-formatting-for-chained-method-calls-in-ternary-expressions-changed">IDEA-387867</a>]</li>
 <li>Pressing the <em>Alt+Enter</em> key combination on Windows no longer opens the context menu unexpectedly. [<a href="https://youtrack.jetbrains.com/issue/IJPL-47743/Alt-key-calls-context-menu-on-Windows">IJPL-47743</a>]</li>
 <li>Live templates with <code>groovyScript</code> now work as expected again. [<a href="https://youtrack.jetbrains.com/issue/IJPL-241581/IDE-2026.1-broke-Live-Templates-with-groovyScript">IJPL-241581</a>]</li>
 <li>Dragging and dropping selected code with the mouse onto its original position no longer causes the code to disappear. [<a href="https://youtrack.jetbrains.com/issue/IJPL-235895/Drag-and-drop-with-mouse-of-code-on-its-own-spot-makes-the-code-disssapear">IJPL-235895</a>]</li>
 <li>Several IDE freezes have been resolved. [<a href="https://youtrack.jetbrains.com/issue/IJPL-235455/Long-read-action-in-com.intellij.codeInsight.daemon.impl.HighlightInfoUpdaterImpl.addEvictedInfos">IJPL-235455</a>] [<a href="https://youtrack.jetbrains.com/issue/IJPL-224542/IDE-Freeze-FUS-Telemetry-Deadlock">IJPL-224542</a>] [<a href="https://youtrack.jetbrains.com/issue/IJPL-203153/PhpStorm-2025.2-Freezes-After-Update-with-settingsSync-enabled-stuck-in-R.e.getIdToken">IJPL-203153</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2026/05/intellij-idea-2026-1-2/">blog post</a>.</p>
    