### PR TITLE
Upgrading IntelliJ from 2026.1.2 to 2026.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [4.0.2] - 2026-05-16
 
 ### Changed
+- Upgrading IntelliJ from 2026.1.2 to 2026.1.3
 
 - Upgrading IntelliJ from 2026.1.1 to 2026.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/git-push-reminder-jetbrains
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 4.0.2
+pluginVersion = 4.0.3
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 261.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.1.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.1.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -33,7 +33,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.1.2
+platformVersion = 2026.1.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1.2 to 2026.1.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662689

# What's New?
<p>IntelliJ IDEA 2026.1.3 is out! The latest update brings the following improvements:</p>
<ul>
 <li>In tmux, the terminal cursor is no longer rendered above the current line. [<a href="https://youtrack.jetbrains.com/issue/IJPL-102697">IJPL-102697</a>]</li>
 <li>The Markdown preview now correctly displays images when referencing files outside the project directory. [<a href="https://youtrack.jetbrains.com/issue/IJPL-171896">IJPL-171896</a>]</li>
 <li>Custom colors are rendered correctly in various UI components in the Database tool window. [<a href="https://youtrack.jetbrains.com/issue/DBE-25711">DBE-25711</a>]</li>
 <li>Launching WSL via wsl.exe -d &lt;distribution&gt; no longer causes shell integration and process detection issues. [<a href="https://youtrack.jetbrains.com/issue/IJPL-236576">IJPL-236576</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2026/06/intellij-idea-2026-1-3/">blog post</a>.</p>
    