### PR TITLE
Upgrading IntelliJ from 2026.1.3 to 2026.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [4.0.2] - 2026-05-16
 
 ### Changed
+- Upgrading IntelliJ from 2026.1.3 to 2026.1.4
 - Upgrading IntelliJ from 2026.1.2 to 2026.1.3
 
 - Upgrading IntelliJ from 2026.1.1 to 2026.1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/git-push-reminder-jetbrains
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 4.0.3
+pluginVersion = 4.0.4
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 261.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.1.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.1.4,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -33,7 +33,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.1.3
+platformVersion = 2026.1.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1.3 to 2026.1.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662699

# What's New?
<p>IntelliJ IDEA 2026.1.4 is out with the following improvements:</p>
<ul>
 <li>The active Git branch now updates correctly. [<a href="https://youtrack.jetbrains.com/issue/IJPL-240184/Git-update-is-disabled-on-the-active-branch">IJPL-240184</a>]</li>
 <li>Fixed an issue where using <code>pull_policy</code> in Docker Compose files prevented the PHP interpreter from being created. [<a href="https://youtrack.jetbrains.com/issue/IJPL-189121/">IJPL-189121</a>]</li>
 <li>The IDE no longer erroneously marks successful Gradle syncs as failed when running Gradle 9.5.0 on WSL. [<a href="https://youtrack.jetbrains.com/issue/IDEA-388949/Gradle-Successful-sync-shown-as-failed-since-Gradle-9.5.0-on-WSL">IDEA-388949</a>]</li>
 <li>Fixed an error that caused Dev Container connections to fail with an <em>Unknown Docker endpoint schema</em> message. [<a href="https://youtrack.jetbrains.com/issue/IJPL-240184/Git-update-is-disabled-on-the-active-branch">IJPL-240184</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2026/06/intellij-idea-2026-1-4/">blog post</a>.</p>
    