### PR TITLE
Upgrading IntelliJ from 2026.1.4 to 2026.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [4.0.2] - 2026-05-16
 
 ### Changed
+- Upgrading IntelliJ from 2026.1.4 to 2026.2
 - Upgrading IntelliJ from 2026.1.3 to 2026.1.4
 - Upgrading IntelliJ from 2026.1.2 to 2026.1.3
 

--- a/buildSrc/src/main/kotlin/build-standard-jetbrains-plugin-build.gradle.kts
+++ b/buildSrc/src/main/kotlin/build-standard-jetbrains-plugin-build.gradle.kts
@@ -13,7 +13,6 @@ fun environment(key: String): Provider<String> = providers.environmentVariable(k
 fun extra(key: String): String = project.ext.get(key) as String
 
 val javaVersion = properties("javaVersion")
-val platformBundledModules = providers.gradleProperty("platformBundledModules").orElse("")
 val platformBundledPlugins = providers.gradleProperty("platformBundledPlugins")
 val platformBundledModules = providers.gradleProperty("platformBundledModules")
 val platformPlugins = providers.gradleProperty("platformPlugins")

--- a/buildSrc/src/main/kotlin/build-standard-jetbrains-plugin-build.gradle.kts
+++ b/buildSrc/src/main/kotlin/build-standard-jetbrains-plugin-build.gradle.kts
@@ -13,6 +13,7 @@ fun environment(key: String): Provider<String> = providers.environmentVariable(k
 fun extra(key: String): String = project.ext.get(key) as String
 
 val javaVersion = properties("javaVersion")
+val platformBundledModules = providers.gradleProperty("platformBundledModules").orElse("")
 val platformBundledPlugins = providers.gradleProperty("platformBundledPlugins")
 val platformPlugins = providers.gradleProperty("platformPlugins")
 val platformVersion = properties("platformVersion")
@@ -65,6 +66,8 @@ dependencies {
         plugins(platformPlugins.map { it.split(',') })
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugins(platformBundledPlugins.map { it.split(',') })
+        // Module Dependencies. Uses `platformBundledModules` property from the gradle.properties file for bundled IntelliJ Platform modules.
+        bundledModules(platformBundledModules.map { it.split(',').map { m -> m.trim() }.filter { m -> m.isNotEmpty() } })
         testFramework(TestFrameworkType.Platform)
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,16 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/git-push-reminder-jetbrains
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 4.0.4
+pluginVersion = 4.1.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 261
-pluginUntilBuild = 261.*
+pluginSinceBuild = 262
+pluginUntilBuild = 262.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.1.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `projectCloseHandler` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
@@ -33,7 +33,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.1.4
+platformVersion = 2026.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,6 +40,9 @@ platformVersion = 2026.2
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins = Git4Idea
+# Module Dependencies. Uses `platformBundledModules` property for bundled IntelliJ Platform modules.
+# Required in 2026.2+ where dvcs and vcs.impl modules are no longer auto-included on the compile classpath.
+platformBundledModules = intellij.platform.vcs.dvcs,intellij.platform.vcs.dvcs.impl,intellij.platform.vcs.impl
 
 # Java language level used to compile sources and to generate the files for
 # - Java 11 is required since 2020.3


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1.4 to 2026.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662707

# What's New?
<p>IntelliJ IDEA 2026.2 is now out! The highlights of this release include:</p>
<p>AI upgrades:</p>
<ul>
 <li>Native GitHub Copilot integration</li>
 <li>Agent skills</li>
 <li>AI completion support for third-party providers</li>
</ul>
<p>Productivity-enhancing features:</p>
<ul>
 <li>Logpoints</li>
 <li>Dependency completion</li>
 <li>Early Gradle 10 support and migration assistance</li>
 <li>Streamlined Git conflict resolution flow</li>
 <li>Docker Compose improvements</li>
</ul>
<p>Support for new technologies:</p>
<ul>
 <li>Java 27</li>
 <li>Kotlin 2.4 Stable features</li>
 <li>Spring support improvements</li>
 <li>Terraform testing framework</li>
 <li>TypeScript 7.0</li>
</ul>
<p>Visit our <a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about these and other improvements.</p>
    